### PR TITLE
Adjust cpu_opp_table for H96-MAX-X3

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-sm1-h96-max-x3.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-sm1-h96-max-x3.dts
@@ -289,30 +289,31 @@
 
 &cpu_opp_table {
 	opp-100000000 {
-		status = "disabled";
+		opp-hz = <0x00 100000000>;
+		opp-microvolt = <730000>;
 	};
 
 	opp-250000000 {
-		status = "disabled";
+		opp-hz = <0x00 250000000>;
+		opp-microvolt = <730000>;
 	};
 
 	opp-500000000 {
+		opp-hz = <0x00 500000000>;
+		opp-microvolt = <730000>;
+	};
+
+	opp-667000000 {
+		opp-hz = <0x00 667000000>;
+		opp-microvolt = <730000>;
+	};
+	
+	opp-2016000000 {
 		status = "disabled";
 	};
-
-	opp-750000000 {
-		opp-hz = /bits/ 64 <750000000>;
-		opp-microvolt = <750000>;
-	};
-
-	opp-2016000000 {
-		opp-hz = /bits/ 64 <2016000000>;
-		opp-microvolt = <1000000>;
-	};
-
+	
 	opp-2100000000 {
-		opp-hz = /bits/ 64 <2100000000>;
-		opp-microvolt = <1011000>;
+		status = "disabled";
 	};
 };
 


### PR DESCRIPTION
According to the original image of Android. Elevated frequencies periodically lead to a kernel panic. There is OC dtb for this.