### PR TITLE
fix unusuable eMMC on some H6 boards

### DIFF
--- a/drivers/mmc/host/sunxi-mmc.c
+++ b/drivers/mmc/host/sunxi-mmc.c
@@ -1405,7 +1405,9 @@ static int sunxi_mmc_probe(struct platform_device *pdev)
 	 */
 	if ((host->cfg->clk_delays || host->use_new_timings) &&
 	    !of_device_is_compatible(pdev->dev.of_node,
-				     "allwinner,sun50i-h5-emmc"))
+				     "allwinner,sun50i-h5-emmc") &&
+	    !of_device_is_compatible(pdev->dev.of_node,
+		    		     "allwinner,sun50i-h6-emmc"))
 		mmc->caps      |= MMC_CAP_1_8V_DDR | MMC_CAP_3_3V_DDR;
 
 	ret = mmc_of_parse(mmc);


### PR DESCRIPTION
mmc: sunxi: fix unusuable eMMC on some H6 boards by disabling DDR 
from https://groups.google.com/d/topic/linux-sunxi/8Z20PtRP-gY