### PR TITLE
arch: arm64: dts: amlogic: Add meson-sm1-x96-max-plus-a100.dts

### DIFF
--- a/arch/arm64/boot/dts/amlogic/Makefile
+++ b/arch/arm64/boot/dts/amlogic/Makefile
@@ -110,6 +110,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-max-plus.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-max-plus-oc.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-max-plus-ip1001m.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-max-plus-ip1001m-2.dtb
+dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-max-plus-a100.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-max-plus-100m.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-max-plus-q1.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-sm1-x96-max-plus-q2.dtb

--- a/arch/arm64/boot/dts/amlogic/meson-sm1-x96-max-plus-a100.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-sm1-x96-max-plus-a100.dts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2024 taras-filatov, unifreq.
+ */
+
+/dts-v1/;
+
+#include "meson-sm1-sei610.dts"
+
+/ {
+	compatible = "x96-max-a100", "amlogic,sm1";
+	model = "X96 MAX+ A100";
+
+	/delete-node/ memory@0;
+
+	memory@0 {
+		device_type = "memory";
+		// reg = <0x0 0x0 0x0 0x40000000>;
+		linux,usable-memory = <0x0 0x100000 0x0 0xf0800000>;
+	};
+};


### PR DESCRIPTION
添加X96MAX+A100(s905x3)专用dtb，可正确识别设备的4G内存。